### PR TITLE
fix: limit messages listed

### DIFF
--- a/tests/2FA.spec.ts
+++ b/tests/2FA.spec.ts
@@ -7,7 +7,7 @@ const client = require("twilio")(accountSid, authToken);
 let record: any;
 
 test.beforeAll(async () => {
-  const response = await client.messages.list();
+  const response = await client.messages.list({limit: 1);
   record = await response[0];
 });
 


### PR DESCRIPTION
### Description: 
- Given a Twilio account has a large number of messages, invoking `client.messages.list()` causes the test to timeout
- This might be helpful as an example for other people following the blog post